### PR TITLE
Grid improvements

### DIFF
--- a/lib/changelog.md
+++ b/lib/changelog.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## dev
+
+- changed behaviour of `Grid.map`, after applying the function it doesn't order or change the list anymore
+- besides values there's now postitions_and_values as well `Grid.positions_and_values(grid)`
+- sorted_list asc(cending) `Grid.sorted_list(grid, :asc)` and cartesian `Grid.sorted_list(grid, :cartesian)`
+
+## 0.1.0
+
+- Extracted Grid and Torus from Thundermoon
+- Extracted AccessProxy from Livebook

--- a/lib/object/grid.ex
+++ b/lib/object/grid.ex
@@ -80,7 +80,7 @@ defmodule Ximula.Grid do
 
   # return the grid as a list
   # note: the order of the values may be in random order
-  def position_and_values(grid) do
+  def positions_and_values(grid) do
     map(grid, fn x, y, value -> {x, y, value} end)
   end
 
@@ -100,13 +100,13 @@ defmodule Ximula.Grid do
 
   def sorted_list(grid, :asc) do
     grid
-    |> position_and_values()
+    |> positions_and_values()
     |> Enum.sort_by(fn {x, y, _v} -> {y, x} end)
   end
 
   def sorted_list(grid, :cartesian) do
     grid
-    |> position_and_values()
+    |> positions_and_values()
     |> Enum.sort_by(fn {x, y, _v} -> {-y, x} end)
   end
 

--- a/lib/object/grid.ex
+++ b/lib/object/grid.ex
@@ -73,14 +73,41 @@ defmodule Ximula.Grid do
   end
 
   # return the grid as a list
-  # note: the order of the values may be in random
+  # note: the order of the values may be in random order
   def values(grid) do
-    Enum.map(grid, fn {_x, col} ->
-      Enum.map(col, fn {_y, value} ->
-        value
+    map(grid, fn _x, _y, value -> value end)
+  end
+
+  # return the grid as a list
+  # note: the order of the values may be in random order
+  def position_and_values(grid) do
+    map(grid, fn x, y, value -> {x, y, value} end)
+  end
+
+  # return the grid as a list
+  # note: the order of the values may be in random order
+  def map(grid, func \\ &{&1, &2, &3}) do
+    Enum.map(grid, fn {x, col} ->
+      Enum.map(col, fn {y, value} ->
+        func.(x, y, value)
       end)
     end)
     |> List.flatten()
+  end
+
+  @spec sorted_list(any()) :: list()
+  def sorted_list(grid), do: sorted_list(grid, :asc)
+
+  def sorted_list(grid, :asc) do
+    grid
+    |> position_and_values()
+    |> Enum.sort_by(fn {x, y, _v} -> {y, x} end)
+  end
+
+  def sorted_list(grid, :cartesian) do
+    grid
+    |> position_and_values()
+    |> Enum.sort_by(fn {x, y, _v} -> {-y, x} end)
   end
 
   # note: the order of the values may be in random
@@ -92,21 +119,6 @@ defmodule Ximula.Grid do
       |> Enum.map(&(&1 |> Tuple.to_list() |> List.last()))
     end)
     |> List.flatten()
-  end
-
-  # [{x0, y0, value}, {x1, y0, value}, ...]
-  def map(grid, func \\ &{&1, &2, &3}) do
-    Enum.map(grid, fn {x, col} ->
-      Enum.map(col, fn {y, value} ->
-        {func.(x, y, value)}
-      end)
-    end)
-    |> Enum.reverse()
-    |> Enum.zip()
-    |> Enum.map(&Tuple.to_list/1)
-    |> List.flatten()
-    |> Enum.map(fn {i} -> i end)
-    |> Enum.reverse()
   end
 
   def merge_field(grid, x, y, value, func \\ &Map.merge(&1, &2)) do

--- a/test/object/grid_test.exs
+++ b/test/object/grid_test.exs
@@ -72,6 +72,11 @@ defmodule Ximula.GridTest do
     assert [{0, 0}, {0, 1}, {1, 0}, {1, 1}] = Grid.values(grid)
   end
 
+  test "position_and_values" do
+    grid = Grid.create(2, 2, fn x, y -> x + y end)
+    assert [{0, 0, 0}, {0, 1, 1}, {1, 0, 1}, {1, 1, 2}] = Grid.position_and_values(grid)
+  end
+
   test "filter" do
     grid = Grid.create(2, 3, fn x, y -> %{sum: x + y} end)
     results = Grid.filter(grid, fn x, y, _v -> rem(x, 2) == 0 && rem(y, 2) == 0 end)
@@ -82,15 +87,37 @@ defmodule Ximula.GridTest do
     grid = Grid.create(2, 3, fn x, y -> x + y end)
 
     expected = [
-      [0, 2, 2],
-      [1, 2, 3],
-      [0, 1, 1],
-      [1, 1, 2],
-      [0, 0, 0],
-      [1, 0, 1]
+      {0, 0, 0},
+      {0, 1, 1},
+      {0, 2, 2},
+      {1, 0, 1},
+      {1, 1, 2},
+      {1, 2, 3}
     ]
 
-    assert ^expected = Grid.map(grid, fn x, y, v -> [x, y, v] end)
+    assert ^expected = Grid.map(grid, fn x, y, v -> {x, y, v} end)
+  end
+
+  test "asc sorted_list" do
+    grid = Grid.create(100, 50, 1) |> Grid.sorted_list()
+    assert {0, 0, 1} == Enum.at(grid, 0)
+    assert {1, 0, 1} == Enum.at(grid, 1)
+    assert {2, 0, 1} == Enum.at(grid, 2)
+    assert {0, 1, 1} == Enum.at(grid, 100)
+    assert {0, 2, 1} == Enum.at(grid, 200)
+    assert {0, 3, 1} == Enum.at(grid, 300)
+    assert {99, 49, 1} == Enum.at(grid, 4999)
+  end
+
+  test "cart sorted_list" do
+    grid = Grid.create(100, 50, 1) |> Grid.sorted_list(:cartesian)
+    assert {0, 49, 1} == Enum.at(grid, 0)
+    assert {1, 49, 1} == Enum.at(grid, 1)
+    assert {2, 49, 1} == Enum.at(grid, 2)
+    assert {0, 48, 1} == Enum.at(grid, 100)
+    assert {0, 47, 1} == Enum.at(grid, 200)
+    assert {0, 46, 1} == Enum.at(grid, 300)
+    assert {99, 0, 1} == Enum.at(grid, 4999)
   end
 
   test "merge field" do

--- a/test/object/grid_test.exs
+++ b/test/object/grid_test.exs
@@ -57,6 +57,16 @@ defmodule Ximula.GridTest do
     assert {:error, _msg} = Grid.put(grid, "two", "one", "foo")
   end
 
+  test "width" do
+    grid = Grid.create(6, 3, "one")
+    assert 6 == Grid.width(grid)
+  end
+
+  test "height" do
+    grid = Grid.create(6, 3, "one")
+    assert 3 == Grid.height(grid)
+  end
+
   test "values" do
     grid = Grid.create(2, 2, fn x, y -> {x, y} end)
     assert [{0, 0}, {0, 1}, {1, 0}, {1, 1}] = Grid.values(grid)

--- a/test/object/grid_test.exs
+++ b/test/object/grid_test.exs
@@ -72,9 +72,9 @@ defmodule Ximula.GridTest do
     assert [{0, 0}, {0, 1}, {1, 0}, {1, 1}] = Grid.values(grid)
   end
 
-  test "position_and_values" do
+  test "positions_and_values" do
     grid = Grid.create(2, 2, fn x, y -> x + y end)
-    assert [{0, 0, 0}, {0, 1, 1}, {1, 0, 1}, {1, 1, 2}] = Grid.position_and_values(grid)
+    assert [{0, 0, 0}, {0, 1, 1}, {1, 0, 1}, {1, 1, 2}] = Grid.positions_and_values(grid)
   end
 
   test "filter" do


### PR DESCRIPTION
- changed behaviour of `Grid.map`, after applying the function it doesn't order or change the list anymore
- besides values there's now postitions_and_values as well `Grid.positions_and_values(grid)`
- sorted_list asc(cending) `Grid.sorted_list(grid, :asc)` and cartesian `Grid.sorted_list(grid, :cartesian)`