### PR TITLE
get and set with tuple coordinates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## dev
+
+Grid:
+
+- allow accessing a grid with a tuple of coordination values `Grid.get(grid, {x, y})`
+
 ## 0.2.0
 
 Grid:

--- a/lib/object/grid.ex
+++ b/lib/object/grid.ex
@@ -34,6 +34,8 @@ defmodule Ximula.Grid do
     end)
   end
 
+  def get(grid, {x, y}), do: get(grid, x, y)
+
   def get(nil, _x, _y), do: {:error, "grid is nil"}
 
   def get(%{0 => columns} = grid, x, y)
@@ -49,6 +51,8 @@ defmodule Ximula.Grid do
   def get(_grid, x, y) do
     {:error, "only integers are allowed as coordinates, x: #{x}, y: #{y}"}
   end
+
+  def put(grid, {x, y}, value), do: put(grid, x, y, value)
 
   def put(%{0 => columns} = grid, x, y, value)
       when x >= 0 and x < map_size(grid) and y >= 0 and y < map_size(columns) do

--- a/lib/object/torus.ex
+++ b/lib/object/torus.ex
@@ -8,6 +8,8 @@ defmodule Ximula.Torus do
   defdelegate width(grid), to: Grid
   defdelegate height(grid), to: Grid
 
+  def get(grid, {x, y}), do: get(grid, x, y)
+
   def get(grid, x, y) when is_integer(x) and x >= map_size(grid) do
     get(grid, x - width(grid), y)
   end
@@ -25,6 +27,8 @@ defmodule Ximula.Torus do
   end
 
   defdelegate get(grid, x, y), to: Grid
+
+  def put(grid, {x, y}, value), do: put(grid, x, y, value)
 
   def put(grid, x, y, value) when is_integer(x) and x >= map_size(grid) do
     put(grid, x - width(grid), y, value)

--- a/test/object/grid_test.exs
+++ b/test/object/grid_test.exs
@@ -30,7 +30,14 @@ defmodule Ximula.GridTest do
     assert 3 == Grid.get(grid, 2, 2)
   end
 
-  test "set and read from grid" do
+  test "set and read from grid with coordination tuple" do
+    grid = Grid.create(2, 3)
+    assert nil == Grid.get(grid, {1, 2})
+    new_grid = Grid.put(grid, {1, 2}, "value")
+    assert "value" == Grid.get(new_grid, {1, 2})
+  end
+
+  test "set and read from grid with coordination arguments" do
     grid = Grid.create(2, 3)
     assert nil == Grid.get(grid, 1, 2)
     new_grid = Grid.put(grid, 1, 2, "value")

--- a/test/object/torus_test.exs
+++ b/test/object/torus_test.exs
@@ -8,7 +8,14 @@ defmodule Ximula.TorusTest do
     assert %{0 => %{0 => nil, 1 => nil, 2 => nil}, 1 => %{0 => nil, 1 => nil, 2 => nil}} = grid
   end
 
-  test "set and read from grid" do
+  test "set and read from grid with coordination tuple" do
+    grid = Grid.create(2, 3)
+    assert nil == Grid.get(grid, {1, 2})
+    new_grid = Grid.put(grid, {1, 2}, "value")
+    assert "value" == Grid.get(new_grid, {1, 2})
+  end
+
+  test "set and read from grid with coordination arguments" do
     grid = Grid.create(2, 3, fn x, y -> {x, y} end)
     assert {1, 2} == Grid.get(grid, 1, 2)
     new_grid = Grid.put(grid, 1, 2, "value")


### PR DESCRIPTION
allow accessing a grid with a tuple of coordination values `Grid.get(grid, {x, y})`