### PR TITLE
remove set_queue, add_queue adds or removes queues

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,14 @@
 
 ## dev
 
+Sim.Loop:
+
+- remove `set_queue`, `add_queue` now replaces queues with the same name
+
 Grid:
 
 - allow accessing a grid with a tuple of coordination values `Grid.get(grid, {x, y})`
+
 
 ## 0.2.0
 

--- a/lib/sim/loop.ex
+++ b/lib/sim/loop.ex
@@ -29,13 +29,9 @@ defmodule Ximula.Sim.Loop do
     GenServer.call(server, :get_queues)
   end
 
+  # adds or replaces a queue with the same name
   def add_queue(server \\ __MODULE__, %Queue{} = queue) do
     GenServer.cast(server, {:add_queue, queue})
-  end
-
-  # adds or replaces a queue with the same name
-  def set_queue(server \\ __MODULE__, %Queue{} = queue) do
-    GenServer.cast(server, {:set_queue, queue})
   end
 
   def clear(server \\ __MODULE__) do
@@ -69,10 +65,6 @@ defmodule Ximula.Sim.Loop do
   end
 
   def handle_cast({:add_queue, queue}, state) do
-    {:noreply, %{state | queues: [queue | state.queues]}}
-  end
-
-  def handle_cast({:set_queue, queue}, state) do
     queues =
       case Enum.find_index(state.queues, &(&1.name == queue.name)) do
         nil -> [queue | state.queues]

--- a/test/sim/loop_test.exs
+++ b/test/sim/loop_test.exs
@@ -21,25 +21,25 @@ defmodule Ximula.Sim.LoopTest do
 
     test "add queue", %{loop: loop} do
       assert [] == Loop.get_queues(loop)
-      :ok = Loop.add_queue(%Queue{name: "first"})
+      :ok = Loop.add_queue(loop, %Queue{name: "first"})
       assert [queue] = Loop.get_queues(loop)
       assert "first" == queue.name
     end
 
-    test "set queue", %{loop: loop} do
+    test "add multiple queues", %{loop: loop} do
       assert [] == Loop.get_queues(loop)
-      :ok = Loop.add_queue(%Queue{name: "first"})
-      :ok = Loop.set_queue(%Queue{name: "second"})
+      :ok = Loop.add_queue(loop, %Queue{name: "first"})
+      :ok = Loop.add_queue(loop, %Queue{name: "second"})
       assert 2 == Loop.get_queues(loop) |> Enum.count()
       assert %Queue{name: "second"} = Loop.get_queues(loop) |> Enum.find(&(&1.name == "second"))
     end
 
     test "replace queue", %{loop: loop} do
       assert [] == Loop.get_queues(loop)
-      :ok = Loop.add_queue(%Queue{name: "first", interval: 5})
-      :ok = Loop.set_queue(%Queue{name: "first", interval: 10})
+      :ok = Loop.add_queue(loop, %Queue{name: "first", interval: 5})
+      :ok = Loop.add_queue(loop, %Queue{name: "first", interval: 10})
       assert 1 == Loop.get_queues(loop) |> Enum.count()
-      assert %Queue{name: "first", interval: 10} = Loop.get_queues(loop) |> List.first()
+      assert %Queue{name: "first", interval: 10} == Loop.get_queues(loop) |> List.first()
     end
   end
 


### PR DESCRIPTION
Sim.Loop:
remove `set_queue`, `add_queue` now replaces queues with the same name