### PR TITLE
update action checkout and cache to v4

### DIFF
--- a/.github/workflows/credo.yml
+++ b/.github/workflows/credo.yml
@@ -40,7 +40,7 @@ jobs:
         otp: ["26.0"]
         elixir: ["1.15.2"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
           elixir-version: "1.15.2" # [Required] Define the Elixir version
           otp-version: "26.0" # [Required] Define the Erlang/OTP version
       - name: Restore dependencies cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}


### PR DESCRIPTION
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.